### PR TITLE
Use args instead of command in pod spec

### DIFF
--- a/reactive/tf_serving.py
+++ b/reactive/tf_serving.py
@@ -70,8 +70,7 @@ def start_charm():
                         "username": image_info.username,
                         "password": image_info.password,
                     },
-                    "command": [
-                        "/usr/bin/tensorflow_model_server",
+                    "args": [
                         f"--port={grpc_port}",
                         f"--rest_api_port={rest_port}",
                     ]


### PR DESCRIPTION
Allows substituting in a different docker image with a custom entrypoint